### PR TITLE
Link created family/insuree to mutation

### DIFF
--- a/insuree/gql_mutations.py
+++ b/insuree/gql_mutations.py
@@ -13,7 +13,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.utils.translation import gettext as _
 from graphene import InputObjectType
-from .models import Family, Insuree, InsureePhoto, InsureePolicy
+from .models import Family, Insuree, InsureePhoto, InsureePolicy, FamilyMutation, InsureeMutation
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,9 @@ class CreateFamilyMutation(OpenIMISMutation):
             data['audit_user_id'] = user.id_for_audit
             from core.utils import TimeUtils
             data['validity_from'] = TimeUtils.now()
-            update_or_create_family(data, user)
+            client_mutation_id = data.get("client_mutation_id")
+            family = update_or_create_family(data, user)
+            FamilyMutation.object_mutated(user, client_mutation_id=client_mutation_id, family=family)
             return None
         except Exception as exc:
             return [{
@@ -297,7 +299,9 @@ class UpdateFamilyMutation(OpenIMISMutation):
             if not user.has_perms(InsureeConfig.gql_mutation_update_families_perms):
                 raise PermissionDenied(_("unauthorized"))
             data['audit_user_id'] = user.id_for_audit
-            update_or_create_family(data, user)
+            client_mutation_id = data.get("client_mutation_id")
+            family = update_or_create_family(data, user)
+            FamilyMutation.object_mutated(user, client_mutation_id=client_mutation_id, family=family)
             return None
         except Exception as exc:
             return [{
@@ -384,7 +388,9 @@ class CreateInsureeMutation(OpenIMISMutation):
             data['audit_user_id'] = user.id_for_audit
             from core.utils import TimeUtils
             data['validity_from'] = TimeUtils.now()
-            update_or_create_insuree(data, user)
+            client_mutation_id = data.get("client_mutation_id")
+            insuree = update_or_create_insuree(data, user)
+            InsureeMutation.object_mutated(user, client_mutation_id=client_mutation_id, insuree=insuree)
             return None
         except Exception as exc:
             return [{
@@ -412,7 +418,9 @@ class UpdateInsureeMutation(OpenIMISMutation):
             if not user.has_perms(InsureeConfig.gql_mutation_create_insurees_perms):
                 raise PermissionDenied(_("unauthorized"))
             data['audit_user_id'] = user.id_for_audit
-            update_or_create_insuree(data, user)
+            client_mutation_id = data.get("client_mutation_id")
+            insuree = update_or_create_insuree(data, user)
+            InsureeMutation.object_mutated(user, client_mutation_id=client_mutation_id, insuree=insuree)
             return None
         except Exception as exc:
             return [{

--- a/insuree/gql_queries.py
+++ b/insuree/gql_queries.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene_django import DjangoObjectType
 from .models import Insuree, InsureePhoto, Education, Profession, Gender, IdentificationType, \
-    Family, FamilyType, ConfirmationType, Relation, InsureePolicy
+    Family, FamilyType, ConfirmationType, Relation, InsureePolicy, FamilyMutation, InsureeMutation
 from location.schema import LocationGQLType
 from policy.gql_queries import PolicyGQLType
 from core import prefix_filterset, filter_validity, ExtendedConnection
@@ -154,3 +154,13 @@ class InsureePolicyGQLType(DjangoObjectType):
     @classmethod
     def get_queryset(cls, queryset, info):
         return InsureePolicy.get_queryset(queryset, info)
+
+
+class FamilyMutationGQLType(DjangoObjectType):
+    class Meta:
+        model = FamilyMutation
+
+
+class InsureeMutationGQLType(DjangoObjectType):
+    class Meta:
+        model = InsureeMutation

--- a/insuree/models.py
+++ b/insuree/models.py
@@ -336,22 +336,18 @@ class InsureePolicy(core_models.VersionedModel):
         db_table = 'tblInsureePolicy'
 
 
-class InsureeMutation(core_models.UUIDModel):
-    insuree = models.ForeignKey(Insuree, models.DO_NOTHING,
-                                related_name='mutations')
-    mutation = models.ForeignKey(
-        core_models.MutationLog, models.DO_NOTHING, related_name='insurees')
+class InsureeMutation(core_models.UUIDModel, core_models.ObjectMutation):
+    insuree = models.ForeignKey(Insuree, models.DO_NOTHING, related_name='mutations')
+    mutation = models.ForeignKey(core_models.MutationLog, models.DO_NOTHING, related_name='insurees')
 
     class Meta:
         managed = True
         db_table = "insuree_InsureeMutation"
 
 
-class FamilyMutation(core_models.UUIDModel):
-    family = models.ForeignKey(Family, models.DO_NOTHING,
-                               related_name='mutations')
-    mutation = models.ForeignKey(
-        core_models.MutationLog, models.DO_NOTHING, related_name='families')
+class FamilyMutation(core_models.UUIDModel, core_models.ObjectMutation):
+    family = models.ForeignKey(Family, models.DO_NOTHING, related_name='mutations')
+    mutation = models.ForeignKey(core_models.MutationLog, models.DO_NOTHING, related_name='families')
 
     class Meta:
         managed = True

--- a/insuree/schema.py
+++ b/insuree/schema.py
@@ -55,6 +55,7 @@ class Query(graphene.ObjectType):
         show_history=graphene.Boolean(),
         parent_location=graphene.String(),
         parent_location_level=graphene.Int(),
+        client_mutation_id=graphene.String(),
         orderBy=graphene.List(of_type=graphene.String),
     )
     identification_types = graphene.List(IdentificationTypeGQLType)
@@ -69,6 +70,7 @@ class Query(graphene.ObjectType):
         show_history=graphene.Boolean(),
         parent_location=graphene.String(),
         parent_location_level=graphene.Int(),
+        client_mutation_id=graphene.String(),
         orderBy=graphene.List(of_type=graphene.String),
     )
     family_members = OrderedDjangoFilterConnectionField(
@@ -111,6 +113,9 @@ class Query(graphene.ObjectType):
         show_history = kwargs.get('show_history', False)
         if not show_history and not kwargs.get('uuid', None):
             filters += filter_validity(**kwargs)
+        client_mutation_id = kwargs.get("client_mutation_id", None)
+        if client_mutation_id:
+            filters.append(Q(mutations__mutation__client_mutation_id=client_mutation_id))
         parent_location = kwargs.get('parent_location')
         if parent_location is not None:
             parent_location_level = kwargs.get('parent_location_level')
@@ -162,6 +167,9 @@ class Query(graphene.ObjectType):
         show_history = kwargs.get('show_history', False)
         if not show_history:
             filters += filter_validity(**kwargs)
+        client_mutation_id = kwargs.get("client_mutation_id", None)
+        if client_mutation_id:
+            filters.append(Q(mutations__mutation__client_mutation_id=client_mutation_id))
         parent_location = kwargs.get('parent_location')
         if parent_location is not None:
             parent_location_level = kwargs.get('parent_location_level')


### PR DESCRIPTION
This system was already implemented in the contribution and payment modules, so we're extending it here so that the web application can go back to the family it just created instead of just staying on a disabled form and returning to an empty search.