### PR TITLE
Insuree number validation missing

### DIFF
--- a/insuree/gql_mutations.py
+++ b/insuree/gql_mutations.py
@@ -4,6 +4,8 @@ import pathlib
 import base64
 from copy import copy
 import graphene
+from insuree.services import validate_insuree_number
+
 from .apps import InsureeConfig
 from core import filter_validity, assert_string_length
 from core.schema import TinyInt, SmallInt, OpenIMISMutation
@@ -199,7 +201,11 @@ def update_or_create_insuree(data, user):
         reset_insuree_before_update(insuree)
         [setattr(insuree, key, data[key]) for key in data]
     else:
-        insuree = Insuree.objects.create(**data)
+        errors = validate_insuree_number(data["chf_id"])
+        if errors:
+            raise Exception("Invalid insuree number")
+        else:
+            insuree = Insuree.objects.create(**data)
     insuree.save()
     photo = handle_insuree_photo(user, now, insuree, photo)
     if photo:
@@ -269,6 +275,10 @@ class CreateFamilyMutation(OpenIMISMutation):
             from core.utils import TimeUtils
             data['validity_from'] = TimeUtils.now()
             client_mutation_id = data.get("client_mutation_id")
+            # Validate insuree number right away
+            errors = validate_insuree_number(data.get("head_insuree", {}).get("chf_id", None))
+            if errors:
+                return errors
             family = update_or_create_family(data, user)
             FamilyMutation.object_mutated(user, client_mutation_id=client_mutation_id, family=family)
             return None
@@ -391,6 +401,10 @@ class CreateInsureeMutation(OpenIMISMutation):
             from core.utils import TimeUtils
             data['validity_from'] = TimeUtils.now()
             client_mutation_id = data.get("client_mutation_id")
+            # Validate insuree number right away
+            errors = validate_insuree_number(data.get("chf_id", None))
+            if errors:
+                return errors
             insuree = update_or_create_insuree(data, user)
             InsureeMutation.object_mutated(user, client_mutation_id=client_mutation_id, insuree=insuree)
             return None

--- a/insuree/gql_queries.py
+++ b/insuree/gql_queries.py
@@ -62,12 +62,14 @@ class ConfirmationTypeGQLType(DjangoObjectType):
             "code": ["exact"]
         }
 
+
 class RelationGQLType(DjangoObjectType):
     class Meta:
         model = Relation
         filter_fields = {
             "code": ["exact"]
         }
+
 
 class InsureeGQLType(DjangoObjectType):
     age = graphene.Int(source='age')

--- a/insuree/schema.py
+++ b/insuree/schema.py
@@ -90,6 +90,18 @@ class Query(graphene.ObjectType):
         orderBy=graphene.List(of_type=graphene.String),
         additional_filter=graphene.JSONString(),
     )
+    insuree_number_validity = graphene.Field(
+        graphene.Boolean,
+        insuree_number=graphene.String(required=True),
+        description="Checks that the specified insuree number is valid"
+    )
+
+    def resolve_insuree_number_validity(self, info, insuree_number=None):
+        errors = validate_insuree_number(insuree_number)
+        if errors:
+            return False
+        else:
+            return True
 
     def resolve_can_add_insuree(self, info, **kwargs):
         family = Family.objects.get(id=kwargs.get('family_id'))
@@ -309,15 +321,15 @@ def on_family_and_insuree_mutation(kwargs):
 
 def on_mutation(sender, **kwargs):
     return {
-        CreateFamilyMutation._mutation_class: lambda x: on_family_mutation(x),
-        UpdateFamilyMutation._mutation_class: lambda x: on_family_mutation(x),
-        DeleteFamiliesMutation._mutation_class: lambda x: on_families_mutation(x),
-        CreateInsureeMutation._mutation_class: lambda x: on_insurees_mutation(x),
-        UpdateInsureeMutation._mutation_class: lambda x: on_insurees_mutation(x),
-        DeleteInsureesMutation._mutation_class: lambda x: on_family_and_insurees_mutation(x),
-        RemoveInsureesMutation._mutation_class: lambda x: on_family_and_insurees_mutation(x),
-        SetFamilyHeadMutation._mutation_class: lambda x: on_family_mutation(x),
-        ChangeInsureeFamilyMutation._mutation_class: lambda x: on_family_and_insuree_mutation(x),
+        CreateFamilyMutation._mutation_class: on_family_mutation,
+        UpdateFamilyMutation._mutation_class: on_family_mutation,
+        DeleteFamiliesMutation._mutation_class: on_families_mutation,
+        CreateInsureeMutation._mutation_class: on_insurees_mutation,
+        UpdateInsureeMutation._mutation_class: on_insurees_mutation,
+        DeleteInsureesMutation._mutation_class: on_family_and_insurees_mutation,
+        RemoveInsureesMutation._mutation_class: on_family_and_insurees_mutation,
+        SetFamilyHeadMutation._mutation_class: on_family_mutation,
+        ChangeInsureeFamilyMutation._mutation_class: on_family_and_insuree_mutation,
     }.get(sender._mutation_class, lambda x: [])(kwargs)
 
 

--- a/insuree/test_graphql.py
+++ b/insuree/test_graphql.py
@@ -1,0 +1,55 @@
+import base64
+import json
+from dataclasses import dataclass
+
+from core.models import User
+from core.test_helpers import create_test_interactive_user
+from django.conf import settings
+from graphene_django.utils.testing import GraphQLTestCase
+from graphql_jwt.shortcuts import get_token
+from location.models import Location
+from location.test_helpers import create_test_location, assign_user_districts
+from rest_framework import status
+
+
+# from openIMIS import schema
+
+
+@dataclass
+class DummyContext:
+    """ Just because we need a context to generate. """
+    user: User
+
+
+class InsureeGQLTestCase(GraphQLTestCase):
+    GRAPHQL_URL = f'/{settings.SITE_ROOT()}graphql'
+    # This is required by some version of graphene but is never used. It should be set to the schema but the import
+    # is shown as an error in the IDE, so leaving it as True.
+    GRAPHQL_SCHEMA = True
+    admin_user = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.admin_user = create_test_interactive_user(username="testLocationAdmin")
+        cls.admin_token = get_token(cls.admin_user, DummyContext(user=cls.admin_user))
+        cls.noright_user = create_test_interactive_user(username="testLocationNoRight", roles=[1])
+        cls.noright_token = get_token(cls.noright_user, DummyContext(user=cls.noright_user))
+        cls.admin_dist_user = create_test_interactive_user(username="testLocationDist")
+        assign_user_districts(cls.admin_dist_user, ["R1D1", "R2D1", "R2D2"])
+        cls.admin_dist_token = get_token(cls.admin_dist_user, DummyContext(user=cls.admin_dist_user))
+
+    def test_query_insuree_number_validity(self):
+        response = self.query(
+            '''
+            {
+                insureeNumberValidity(insureeNumber:"123456782")
+            }
+            ''',
+            headers={"HTTP_AUTHORIZATION": f"JWT {self.admin_token}"},
+        )
+
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+
+        self.assertResponseNoErrors(response)

--- a/insuree/tests.py
+++ b/insuree/tests.py
@@ -1,1 +1,61 @@
-# Create your tests here.
+from django.test import TestCase
+
+from insuree.services import validate_insuree_number
+
+
+class InsureeValidationTest(TestCase):
+    def test_validator(self):
+        def fail1(x):
+            if x == "fail1":
+                return ["fail1"]
+            else:
+                return []
+
+        with self.settings(
+                INSUREE_NUMBER_VALIDATOR=fail1,
+                INSUREE_NUMBER_LENGTH=None,
+                INSUREE_NUMBER_MODULE_ROOT=None):
+            self.assertEqual(validate_insuree_number(None), [])
+            self.assertEqual(validate_insuree_number("valid"), [])
+            self.assertEqual(validate_insuree_number("fail1"), ["fail1"])
+        with self.settings(
+                INSUREE_NUMBER_VALIDATOR=None,
+                INSUREE_NUMBER_LENGTH=None,
+                INSUREE_NUMBER_MODULE_ROOT=None):
+            self.assertEqual(validate_insuree_number(None), [])
+            self.assertEqual(validate_insuree_number("valid"), [])
+            self.assertEqual(validate_insuree_number("fail1"), [])
+
+    def test_len(self):
+        with self.settings(
+                INSUREE_NUMBER_VALIDATOR=None,
+                INSUREE_NUMBER_LENGTH=5,
+                INSUREE_NUMBER_MODULE_ROOT=None):
+            self.assertEqual(len(validate_insuree_number(None)), 1)
+            self.assertEqual(len(validate_insuree_number("")), 1)
+            self.assertEqual(len(validate_insuree_number("foo")), 1)
+            self.assertEqual(len(validate_insuree_number("12345")), 0)
+            self.assertEqual(len(validate_insuree_number("1234567")), 1)
+        with self.settings(
+                INSUREE_NUMBER_VALIDATOR=None,
+                INSUREE_NUMBER_LENGTH=7,
+                INSUREE_NUMBER_MODULE_ROOT=None):
+            self.assertEqual(len(validate_insuree_number("12345")), 1)
+            self.assertEqual(len(validate_insuree_number("1234567")), 0)
+
+    def test_mod(self):
+        with self.settings(
+                INSUREE_NUMBER_VALIDATOR=None,
+                INSUREE_NUMBER_LENGTH=5,
+                INSUREE_NUMBER_MODULE_ROOT=7):
+            self.assertEqual(len(validate_insuree_number(None)), 1)
+            self.assertEqual(len(validate_insuree_number("12342")), 0)
+            self.assertEqual(len(validate_insuree_number("12345")), 1)
+            self.assertEqual(len(validate_insuree_number("1234567")), 1)
+        with self.settings(
+                INSUREE_NUMBER_VALIDATOR=None,
+                INSUREE_NUMBER_LENGTH=7,
+                INSUREE_NUMBER_MODULE_ROOT=5):
+            self.assertEqual(len(validate_insuree_number("12345")), 1)
+            self.assertEqual(len(validate_insuree_number("1234561")), 0)
+            self.assertEqual(len(validate_insuree_number("1234560")), 1)


### PR DESCRIPTION
The insuree number format should be verified. Most of the time, it is a number with a check digit that usually is the modulo 7 of the rest.
I have added this validation into the family and insuree creation mutations directly into the mutation so that they are triggered before anything else. I considered adding it as a signal but it would be a bit buried. It is still possible to use the mutation signals to validate those.
I have also added an insuree number verification query so that frontends can validate those numbers (although they might want to do it in the browser).

This verification allows three kinds of validations:
1. by providing a custom validator function
2. by specifying a length.
3. by specifying a modulo root. This method should be combined with #2.
Configuring these can be done in module configuration, in the settings.py or in the environment.

Sample for settings.py:
```
 def insuree_number_validator(x):
     if str(x)[0] != "x":
         return ["don't start with x"]
     else:
         return []

INSUREE_NUMBER_VALIDATOR = insuree_number_validator
INSUREE_NUMBER_LENGTH = 9
INSUREE_NUMBER_MODULE_ROOT = 7
```
More validations might be added later on.