### PR TITLE
Fix generateinsuree

### DIFF
--- a/insuree/management/commands/generateinsurees.py
+++ b/insuree/management/commands/generateinsurees.py
@@ -12,6 +12,7 @@ class Command(BaseCommand):
     services = None
     items = None
     products = None
+    villages = None
 
     def add_arguments(self, parser):
         parser.add_argument("nb_insurees", nargs=1, type=int)
@@ -47,7 +48,10 @@ class Command(BaseCommand):
                 dob=fake.date_between(start_date='-105y', end_date='today'),
                 chf_id=random.randrange(100000000, 999999999),
             )
-            insuree = create_test_insuree(custom_props=props)
+            family_props = dict(
+                location_id=self.get_random_village(),
+            )
+            insuree = create_test_insuree(custom_props=props, family_custom_props=family_props)
             if verbose:
                 print(insuree_num, "created head insuree and family", insuree.other_names, insuree.last_name,
                       insuree.chf_id)
@@ -63,6 +67,7 @@ class Command(BaseCommand):
             if policy:
                 from policy.test_helpers import create_test_policy_family
                 product = self.get_random_product()
+                # TODO Method doesn't exist anymore
                 policy = create_test_policy_family(product, insuree.family, link=True, valid=True)
                 if verbose:
                     print("Generated policy for family", insuree.family_id, policy)
@@ -72,3 +77,9 @@ class Command(BaseCommand):
             from product.models import Product
             self.products = Product.objects.filter(validity_to__isnull=True).values_list("pk", flat=True)
         return random.choice(self.products)
+
+    def get_random_village(self):
+        if not self.villages:
+            from location.models import Location
+            self.villages = Location.objects.filter(type="V", validity_to__isnull=True).values_list("pk", flat=True)
+        return random.choice(self.villages)

--- a/insuree/test_helpers.py
+++ b/insuree/test_helpers.py
@@ -1,7 +1,7 @@
 from insuree.models import Insuree, Family, Gender, InsureePhoto
 
 
-def create_test_insuree(with_family=True, custom_props=None, family_custom_props={}):
+def create_test_insuree(with_family=True, is_head=False, custom_props=None, family_custom_props=None):
     # insuree has a mandatory reference to family and family has a mandatory reference to insuree
     # So we first insert the family with a dummy id and then update it
     if with_family:
@@ -9,6 +9,7 @@ def create_test_insuree(with_family=True, custom_props=None, family_custom_props
             validity_from="2019-01-01",
             head_insuree_id=1,  # dummy
             audit_user_id=-1,
+            **(family_custom_props if family_custom_props else {})
         )
     else:
         family = None
@@ -21,7 +22,7 @@ def create_test_insuree(with_family=True, custom_props=None, family_custom_props
             "family": family,
             "gender": Gender.objects.get(code='M'),
             "dob": "1970-01-01",
-            "head": True,
+            "head": is_head,
             "card_issued": True,
             "validity_from": "2019-01-01",
             "audit_user_id": -1,

--- a/insuree/test_helpers.py
+++ b/insuree/test_helpers.py
@@ -31,8 +31,9 @@ def create_test_insuree(with_family=True, is_head=False, custom_props=None, fami
     )
     if with_family:
         family.head_insuree_id = insuree.id
-        for k, v in family_custom_props.items():
-            setattr(family, k, v)
+        if family_custom_props:
+            for k, v in family_custom_props.items():
+                setattr(family, k, v)
         family.save()
 
     return insuree


### PR DESCRIPTION
Fixed the `generateinsurees` Django command.

Added missing information when insurees were created.