### PR TITLE
OMT-324 add management commands in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,14 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )


### PR DESCRIPTION
It seems that the management folder missing the __init__.py was causing the commands not to be bundled with the rest. This should allow the generateinsurees command to be available also when installing from pypi