### PR TITLE
feat: Adjustment of the control of the no_location_check parameter via the be-location config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Rights required:
   for adults (default: `60`)
 * renewal_photo_age_child": age (in months) of a picture due for renewal
   for children (default: `12`)
-* no_location_check : if implementation is at a national scale without any Location check for all Users (default: False)
 
 ## openIMIS Modules Dependencies
 * location.models.HealthFacility

--- a/insuree/apps.py
+++ b/insuree/apps.py
@@ -39,7 +39,6 @@ DEFAULT_CFG = {
     "insuree_fsp_mandatory": False,
     "insuree_as_worker": False,
     "is_insuree_photo_required": False,
-    "no_location_check": False,
 }
 
 
@@ -78,7 +77,6 @@ class InsureeConfig(AppConfig):
     insuree_fsp_mandatory = None
     insuree_as_worker = None
     is_insuree_photo_required = None
-    no_location_check = None
 
     def __load_config(self, cfg):
         for field in cfg:

--- a/insuree/models.py
+++ b/insuree/models.py
@@ -10,6 +10,7 @@ from graphql import ResolveInfo
 from insuree.apps import InsureeConfig
 from location import models as location_models
 from location.models import LocationManager
+from location.models import LocationConfig
 
 
 class Gender(models.Model):
@@ -138,7 +139,7 @@ class Family(core_models.VersionedModel, core_models.ExtendableModel):
             queryset = queryset.exclude(
                 members__chf_id__in=InsureeConfig.excluded_insuree_chfids
             )
-        if settings.ROW_SECURITY and not user.is_imis_admin and not InsureeConfig.no_location_check:
+        if settings.ROW_SECURITY and not user.is_imis_admin and not LocationConfig.no_location_check:
             from location.schema import LocationManager
             return queryset.filter(
                 LocationManager().build_user_location_filter_query(user._u, prefix='location__parent__parent', loc_types=['D']))
@@ -314,7 +315,7 @@ class Insuree(core_models.VersionedModel, core_models.ExtendableModel):
         # The insuree "health facility" is the "First Point of Service"
         # (aka the 'preferred/reference' HF for an insuree)
         # ... so not to be used as 'strict filtering'
-        if settings.ROW_SECURITY and not user.is_imis_admin and not InsureeConfig.no_location_check:
+        if settings.ROW_SECURITY and not user.is_imis_admin and not LocationConfig.no_location_check:
             return queryset.filter(
                 Q(LocationManager().build_user_location_filter_query(user._u, prefix='current_village__parent__parent', loc_types=['D']) |
                   LocationManager().build_user_location_filter_query(user._u, prefix='family__location__parent__parent', loc_types=['D']))

--- a/insuree/models.py
+++ b/insuree/models.py
@@ -10,7 +10,7 @@ from graphql import ResolveInfo
 from insuree.apps import InsureeConfig
 from location import models as location_models
 from location.models import LocationManager
-from location.models import LocationConfig
+from location.apps import LocationConfig
 
 
 class Gender(models.Model):

--- a/insuree/schema.py
+++ b/insuree/schema.py
@@ -199,7 +199,7 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
             filters += [(Q(current_village__isnull=False) & Q(**{current_village: parent_location})) |
                         (Q(current_village__isnull=True) & Q(**{family_location: parent_location}))]
 
-        if not info.context.user._u.is_imis_admin and (kwargs.get('ignore_location') == False or kwargs.get('ignore_location') is None) and not InsureeConfig.no_location_check:
+        if not info.context.user._u.is_imis_admin and (kwargs.get('ignore_location') == False or kwargs.get('ignore_location') is None) and not LocationConfig.no_location_check:
             # Limit the list by the logged in user location mapping
             filters += [Q(LocationManager().build_user_location_filter_query(info.context.user._u, prefix='current_village__parent__parent', loc_types=['D']) |
                         LocationManager().build_user_location_filter_query(info.context.user._u, prefix='family__location__parent__parent', loc_types=['D']))]
@@ -288,7 +288,7 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
             filters += [Q(**{f: parent_location})]
 
         # Limit the list by the logged in user location mapping
-        if not info.context.user._u.is_imis_admin and not InsureeConfig.no_location_check:
+        if not info.context.user._u.is_imis_admin and not LocationConfig.no_location_check:
             filters += [LocationManager().build_user_location_filter_query(info.context.user._u,
                                                                            prefix='location__parent__parent', loc_types=['D'])]
 


### PR DESCRIPTION
Adding configuration for national implementation : if implementation is at a national scale without any Location check for all Users (default: False)
The config is already present in the be-location, so we will use the same.