### PR TITLE
fix: Fix error file exist on photo

### DIFF
--- a/insuree/services.py
+++ b/insuree/services.py
@@ -254,7 +254,7 @@ def create_file(date, insuree_id, photo_bin, file_name):
     file_dir = path.join(str(date.year), str(date.month),
                          str(date.day), str(insuree_id))
     _create_dir(file_dir)
-    with open(_photo_dir(file_dir, file_name), "xb") as f:
+    with open(_photo_dir(file_dir, file_name), "wb") as f:
         f.write(base64.b64decode(photo_bin))
         f.close()
     return file_dir, file_name


### PR DESCRIPTION
Some times when the user changes the insuree photo, the be raises and error: File exists
Even after adding your corrections here: https://openimis.atlassian.net/browse/OP-2065, we still encountered this bug. So So we also changed the "xb" et "wb" to allows updating the data in the directory instead of raising the error.