### PR TITLE
OP-2527: Improve Enrolment Officer Selection When Adding Insuree Photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Rights required:
 * renewal_photo_age_child": age (in months) of a picture due for renewal
   for children (default: `12`)
 * no_location_check : if implementation is at a national scale without any Location check for all Users (default: False)
+* use_contextual_enrolment_officer_selection": Enables automatic assignment of 
+  the current user as the enrolment officer when uploading an insuree photo. If 'True', 
+  the officer is inferred from session; if 'False', manual selection remains available. (default: 'False)
 
 ## openIMIS Modules Dependencies
 * location.models.HealthFacility

--- a/insuree/apps.py
+++ b/insuree/apps.py
@@ -40,6 +40,7 @@ DEFAULT_CFG = {
     "insuree_as_worker": False,
     "is_insuree_photo_required": False,
     "no_location_check": False,
+    "use_contextual_enrolment_officer_selection": False
 }
 
 
@@ -79,6 +80,7 @@ class InsureeConfig(AppConfig):
     insuree_as_worker = None
     is_insuree_photo_required = None
     no_location_check = None
+    use_contextual_enrolment_officer_selection = None
 
     def __load_config(self, cfg):
         for field in cfg:

--- a/insuree/schema.py
+++ b/insuree/schema.py
@@ -481,8 +481,8 @@ def _get_contextual_insuree_officers(info, **kwargs):
             # Non-EO user
             user_districts = UserDistrict.get_user_districts(i_user)
             if user_districts:
-                location_uuids = [d.location.uuid for d in user_districts if d.location]
-                officers = Officer.objects.filter(location__uuid__in=location_uuids, validity_to__isnull=True).distinct()
+                location_ids = [d.location_id for d in user_districts if d.location]
+                officers = Officer.objects.filter(location__id__in=location_ids, validity_to__isnull=True).distinct()
                 if officers.exists():
                     return officers
 

--- a/insuree/schema.py
+++ b/insuree/schema.py
@@ -22,6 +22,8 @@ from location.apps import LocationConfig
 from core.schema import OrderedDjangoFilterConnectionField, OfficerGQLType
 from core.gql_queries import ValidationMessageGQLType
 from policy.models import Policy
+from core.models import Officer, Role, UserRole
+from location.models import UserDistrict
 
 # We do need all queries and mutations in the namespace here.
 from .gql_queries import *  # lgtm [py/polluting-import]
@@ -300,6 +302,9 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
     def resolve_insuree_officers(self, info, **kwargs):
         if not info.context.user.has_perms(InsureeConfig.gql_query_insuree_officers_perms):
             raise PermissionDenied(_("unauthorized"))
+        
+        if InsureeConfig.use_contextual_enrolment_officer_selection:
+            return _get_contextual_insuree_officers(info, **kwargs)
 
     def resolve_insuree_policy(self, info, **kwargs):
         if not info.context.user.has_perms(InsureeConfig.gql_query_insuree_policy_perms):
@@ -453,3 +458,34 @@ def _get_additional_filter(sender, additional_filter, user, signal: Signal):
         )
         filters_from_signal = _read_signal_results(results_signal)
     return filters_from_signal
+
+def _get_contextual_insuree_officers(info, **kwargs):
+        if not info.context.user.has_perms(InsureeConfig.gql_query_insuree_officers_perms):
+            raise PermissionDenied(_("unauthorized"))
+
+        user = info.context.user
+        i_user = getattr(user, '_u', None)
+
+        if i_user:
+            user_roles = UserRole.objects.filter(user_id=i_user.id, validity_to__isnull=True)
+            roles = list(
+                Role.objects.filter(
+                    id__in=user_roles.values_list("role_id", flat=True),
+                    validity_to__isnull=True
+                ).values_list("name", flat=True)
+            )
+            # If the user is an Enrolment Officer (EO)
+            if "Enrolment Officer" in roles:
+                return Officer.objects.filter(id=user.officer.id, validity_to__isnull=True)
+
+            # Non-EO user
+            user_districts = UserDistrict.get_user_districts(i_user)
+            if user_districts:
+                location_uuids = [d.location.uuid for d in user_districts if d.location]
+                officers = Officer.objects.filter(location__uuid__in=location_uuids, validity_to__isnull=True).distinct()
+                if officers.exists():
+                    return officers
+
+        # No officers found → return all valid EOs
+        return Officer.objects.filter(validity_to__isnull=True)
+    

--- a/insuree/schema.py
+++ b/insuree/schema.py
@@ -111,7 +111,10 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
         family_uuid=graphene.String(required=True),
         orderBy=graphene.List(of_type=graphene.String),
     )
-    insuree_officers = DjangoFilterConnectionField(OfficerGQLType)
+    insuree_officers = DjangoFilterConnectionField(
+        OfficerGQLType,
+        location_id=graphene.String()
+    )
     insuree_policy = OrderedDjangoFilterConnectionField(
         InsureePolicyGQLType,
         parent_location=graphene.String(),
@@ -299,12 +302,12 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
         dinstinct_queryset = Family.objects.filter(id__in=ids)
         return gql_optimizer.query(dinstinct_queryset.all(), info)
 
-    def resolve_insuree_officers(self, info, **kwargs):
+    def resolve_insuree_officers(self, info, location_id=None, **kwargs):
         if not info.context.user.has_perms(InsureeConfig.gql_query_insuree_officers_perms):
             raise PermissionDenied(_("unauthorized"))
         
         if InsureeConfig.use_contextual_enrolment_officer_selection:
-            return _get_contextual_insuree_officers(info, **kwargs)
+            return _get_contextual_insuree_officers(info, location_id=location_id, **kwargs)
 
     def resolve_insuree_policy(self, info, **kwargs):
         if not info.context.user.has_perms(InsureeConfig.gql_query_insuree_policy_perms):
@@ -459,13 +462,13 @@ def _get_additional_filter(sender, additional_filter, user, signal: Signal):
         filters_from_signal = _read_signal_results(results_signal)
     return filters_from_signal
 
-def _get_contextual_insuree_officers(info, **kwargs):
+def _get_contextual_insuree_officers(info, location_id=None, **kwargs):
         if not info.context.user.has_perms(InsureeConfig.gql_query_insuree_officers_perms):
             raise PermissionDenied(_("unauthorized"))
 
         user = info.context.user
         i_user = getattr(user, '_u', None)
-
+        
         if i_user:
             user_roles = UserRole.objects.filter(user_id=i_user.id, validity_to__isnull=True)
             roles = list(
@@ -477,12 +480,11 @@ def _get_contextual_insuree_officers(info, **kwargs):
             # If the user is an Enrolment Officer (EO)
             if "Enrolment Officer" in roles:
                 return Officer.objects.filter(id=user.officer.id, validity_to__isnull=True)
-
+            
             # Non-EO user
-            user_districts = UserDistrict.get_user_districts(i_user)
-            if user_districts:
-                location_ids = [d.location_id for d in user_districts if d.location]
-                officers = Officer.objects.filter(location__id__in=location_ids, validity_to__isnull=True).distinct()
+            if location_id:
+                officers = Officer.objects.filter(officer_villages__location__id=location_id, validity_to__isnull=True)
+
                 if officers.exists():
                     return officers
 

--- a/insuree/tests/test_graphql.py
+++ b/insuree/tests/test_graphql.py
@@ -18,9 +18,16 @@ from location.test_helpers import create_test_location, create_test_health_facil
 from insuree.models import Family
 
 from insuree.apps import InsureeConfig
+from unittest.mock import patch
+from core.test_helpers import create_test_officer
+
 # from openIMIS import schema
 
 
+@dataclass
+class DummyContext:
+    """ Just because we need a context to generate. """
+    user: User
 
 
 class InsureeGQLTestCase(openIMISGraphQLTestCase):
@@ -46,6 +53,13 @@ class InsureeGQLTestCase(openIMISGraphQLTestCase):
         cls.photo_base64 = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEW10NBjBBbqAAAAH0lEQVRoge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg=="
 
         cls.photo_base64_2 = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEW10NBjBBbrAAAAH0lEQVRoge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg=="
+        cls.eo_user = create_test_interactive_user(username="Positif")
+        cls.non_eo_user = create_test_interactive_user(username="NonEo", roles = [7, 2, 3, 4, 5, 6])
+        cls.eo_token = get_token(cls.eo_user, DummyContext(user=cls.eo_user))
+        cls.non_eo_token = get_token(cls.non_eo_user, DummyContext(user=cls.non_eo_user))
+        cls.test_officer = create_test_officer(villages = [cls.test_village], custom_props={'code':"Positif",'last_name':"Positif",'other_names':"Le"})
+        cls.eo_user.officer = cls.test_officer
+        cls.eo_user.save()
 
     def test_query_insuree_number_validity(self):
         response = self.query(
@@ -465,3 +479,84 @@ query GetInsureeInquire($chfId: String) {
             # This validates the status code and if you get errors
             self.assertResponseNoErrors(response)
             self.assertTrue(content['data']['insureeNumberValidity']['isValid'])
+
+    def test_insuree_officers_query(self):
+      # Enable contextual filtering in the configuration
+      with patch.object(InsureeConfig, 'use_contextual_enrolment_officer_selection', True):
+          # Case 1: EO user, should return only themselves
+          response = self.query(
+              '''
+              query {
+                  insureeOfficers {
+                      edges {
+                          node {
+                              id
+                              uuid
+                              code
+                              lastName
+                              otherNames
+                          }
+                      }
+                  }
+              }
+              ''',
+              headers={"HTTP_AUTHORIZATION": f"Bearer {self.eo_token}"},
+          )
+          content = json.loads(response.content)
+          self.assertResponseNoErrors(response)
+          officers = content['data']['insureeOfficers']['edges']
+          self.assertEqual(len(officers), 1, "Expected exactly one officer for EO user")
+          self.assertEqual(officers[0]['node']['code'], "Positif", "Expected officer to be the EO user")
+
+          # Case 2: Non-EO user with location_id (village with officer)
+          response = self.query(
+              '''
+              query ($locationId: String!) {
+                  insureeOfficers(locationId: $locationId) {
+                      edges {
+                          node {
+                              id
+                              uuid
+                              code
+                              lastName
+                              otherNames
+                          }
+                      }
+                  }
+              }
+              ''',
+              headers={"HTTP_AUTHORIZATION": f"Bearer {self.non_eo_token}"},
+              variables={"locationId": str(self.test_village.id)},
+          )
+          content = json.loads(response.content)
+          self.assertResponseNoErrors(response)
+          officers = content['data']['insureeOfficers']['edges']
+          self.assertEqual(len(officers), 1, "Expected one officer associated with the village")
+          self.assertEqual(officers[0]['node']['code'], "Positif", "Expected officer associated with the village")
+
+          # Case 3: Non-EO user without location_id or village without officer
+          another_village = create_test_village(custom_props={"code": "ANOTHER"})
+          response = self.query(
+              '''
+              query ($locationId: String!) {
+                  insureeOfficers(locationId: $locationId) {
+                      edges {
+                          node {
+                              id
+                              uuid
+                              code
+                              lastName
+                              otherNames
+                          }
+                      }
+                  }
+              }
+              ''',
+              headers={"HTTP_AUTHORIZATION": f"Bearer {self.non_eo_token}"},
+              variables={"locationId": str(another_village.id)},
+          )
+          content = json.loads(response.content)
+          self.assertResponseNoErrors(response)
+          officers = content['data']['insureeOfficers']['edges']
+          self.assertGreaterEqual(len(officers), 1, "Expected at least one officer (all valid EOs)")
+          self.assertTrue(any(o['node']['code'] == "Positif" for o in officers), "Expected test officer in the list")


### PR DESCRIPTION
When adding a photo for an insuree, the system currently requires selecting an enrolment officer from a list of all officers in the database. This step is time-consuming and unnecessary in some implementations where the officer adding the photo is always the one logged in.

To optimize the workflow, we propose two alternative behaviors, to be controlled via a configuration setting:

📌 Change to do :

Remove Selection from UI, Set in Backend

The frontend does not manage enrolment officer selection.

If the current user connected is not an enrolment officier it’s not possible to save the insuree (even if the user is an admin)

The backend auto-fills the officer field based on the current session.

Easier to manage on frontend, but requires context-aware backend updates.



Several rules that should be considered:

If the user is not an EO but it still has the possibility to create/edit an insuree, the filtered list of EOs that are attached to the Family’s village should be available to select one EO.

If the user is not an EO but it still has the possibility to create/edit an insuree, and there is no EO attached to the Village, full list of EOs should be available to select one EO.

If the user is an EO, the selection is by default the user in readonly mode