### PR TITLE
fix(test): repair corrupted PNG fixture in test_insuree_photo

### DIFF
--- a/insuree/tests/test_insuree_photo.py
+++ b/insuree/tests/test_insuree_photo.py
@@ -50,7 +50,7 @@ class InsureePhotoTest(openIMISGraphQLTestCase):
         cls.test_photo_path = InsureeConfig.insuree_photos_root_path
         cls.test_photo_uuid = str(uuid.uuid4())
         cls.photo_base64 = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEW10NBjBBbqAAAAH0lEQVRoge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg=="
-        cls.photo_base64_2 = "iVBORw03GgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEW10NBjBBbqAAAAH0lEQVRoge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg=="
+        cls.photo_base64_2 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
         cls.test_user = create_test_interactive_user(
             username=cls._TEST_USER_NAME,
             password=cls.test_user_PASSWORD,


### PR DESCRIPTION
## Summary

- `photo_base64_2` starts with `iVBORw03Ggo…` — the `03` corrupts the PNG magic header (valid PNGs base64-encode to `iVBORw0KGgo…`).
- Pillow raises `cannot identify image file` in `test_add_photo_save_db`.
- Replaced with a valid 1x1 transparent PNG so the update path is actually exercised.

## Test plan

- [ ] `test_add_photo_save_db` passes in CI