### PR TITLE
fix(insuree): validate chfId uniqueness in insuree number query

### DIFF
--- a/insuree/services.py
+++ b/insuree/services.py
@@ -70,7 +70,9 @@ def validate_insuree_number(insuree_number, insuree_uuid=None):
     insuree_number = str(insuree_number)
 
     if InsureeConfig.insuree_number_validator:
-        return custom_insuree_number_validation(insuree_number)
+        errors = custom_insuree_number_validation(insuree_number)
+        if errors:
+            return errors
     if InsureeConfig.insuree_number_max_length:
         if not insuree_number:
             return [
@@ -118,13 +120,13 @@ def validate_insuree_number(insuree_number, insuree_uuid=None):
             logger.exception("Failed insuree number validation", exc)
             return [{"errorCode": InsureeConfig.validation_code_invalid_insuree_number_exception,
                      "message": "Insuree number validation failed"}]
-    query = Insuree.objects.filter(
-        chf_id=insuree_number, validity_to__isnull=True)
-    insuree = query.first()
-    if insuree_uuid and insuree and uuid.UUID(insuree.uuid) != uuid.UUID(insuree_uuid):
+    query = Insuree.objects.filter(chf_id=insuree_number, validity_to__isnull=True)
+    if insuree_uuid:
+        query = query.exclude(uuid=insuree_uuid)
+    if query.exists():
         return [{
             "errorCode": InsureeConfig.validation_code_taken_insuree_number,
-            "message": "Insuree number has to be unique, %s exists in system" % insuree_number
+            "message": "Insuree number must be unique, %s already exists" % insuree_number
         }]
 
     

--- a/insuree/tests/test_insuree_validation.py
+++ b/insuree/tests/test_insuree_validation.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 
 from insuree.apps import InsureeConfig
+from insuree.models import Insuree
+from insuree.test_helpers import create_test_insuree
 from insuree.services import validate_insuree_number
 
 
@@ -12,6 +14,16 @@ def fail1(x):
 
 
 class InsureeValidationTest(TestCase):
+    def _unused_insuree_number(self, length, modulo_root=None):
+        for base in range(10 ** (length - 2), 10 ** (length - 1)):
+            if modulo_root:
+                number = f"{base}{base % modulo_root}"
+            else:
+                number = str(base).ljust(length, "0")
+            if not Insuree.objects.filter(chf_id=number, validity_to__isnull=True).exists():
+                return number
+        raise AssertionError("Unable to find an unused insuree number")
+
     def test_validator(self):
 
         InsureeConfig.insuree_number_validator = 'insuree.tests.test_insuree_validation.fail1'
@@ -40,7 +52,7 @@ class InsureeValidationTest(TestCase):
         self.assertEqual(len(validate_insuree_number(None)), 1)
         self.assertEqual(len(validate_insuree_number("")), 1)
         self.assertEqual(len(validate_insuree_number("foo")), 1)
-        self.assertEqual(len(validate_insuree_number("12345")), 0)
+        self.assertEqual(len(validate_insuree_number(self._unused_insuree_number(5))), 0)
         self.assertEqual(len(validate_insuree_number("1234567")), 1)
         InsureeConfig. insuree_number_validator = None
         InsureeConfig.insuree_number_max_length = 7
@@ -48,7 +60,7 @@ class InsureeValidationTest(TestCase):
         InsureeConfig.insuree_number_modulo_root = None
         
         self.assertEqual(len(validate_insuree_number("12345")), 1)
-        self.assertEqual(len(validate_insuree_number("1234567")), 0)
+        self.assertEqual(len(validate_insuree_number(self._unused_insuree_number(7))), 0)
 
     def test_mod(self):
         InsureeConfig. insuree_number_validator = None
@@ -57,7 +69,7 @@ class InsureeValidationTest(TestCase):
         InsureeConfig.insuree_number_modulo_root = 7
         
         self.assertEqual(len(validate_insuree_number(None)), 1)
-        self.assertEqual(len(validate_insuree_number("12342")), 0)
+        self.assertEqual(len(validate_insuree_number(self._unused_insuree_number(5, 7))), 0)
         self.assertEqual(len(validate_insuree_number("12345")), 1)
         self.assertEqual(len(validate_insuree_number("1234567")), 1)
         InsureeConfig. insuree_number_validator = None
@@ -66,5 +78,16 @@ class InsureeValidationTest(TestCase):
         InsureeConfig.insuree_number_modulo_root = 5
         
         self.assertEqual(len(validate_insuree_number("12345")), 1)
-        self.assertEqual(len(validate_insuree_number("1234561")), 0)
+        self.assertEqual(len(validate_insuree_number(self._unused_insuree_number(7, 5))), 0)
         self.assertEqual(len(validate_insuree_number("1234560")), 1)
+
+    def test_uniqueness(self):
+        InsureeConfig.insuree_number_validator = None
+        InsureeConfig.insuree_number_max_length = None
+        InsureeConfig.insuree_number_min_length = None
+        InsureeConfig.insuree_number_modulo_root = None
+
+        insuree = create_test_insuree(custom_props={"chf_id": "123456789"})
+
+        self.assertEqual(len(validate_insuree_number("123456789")), 1)
+        self.assertEqual(validate_insuree_number("123456789", insuree.uuid), [])


### PR DESCRIPTION

## Description

**Validation of insuree number (chfId) uniqueness**

This PR fixes a bug where the system allowed multiple insurees to be registered with the same `chfId`. The issue occurred specifically when creating a new insuree (without an `insuree_uuid`), because the validation did not properly check the existence of the number in the database. The field must now validate uniqueness in real-time, similar to the `claim-code` field in the claim form.

---

## Type of Change

- [x] Bug fix

---

## Related Issue(s) / Task(s)

- [ ] Requires [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR]
- [x] External reference (Jira): Evolution #35932

---

## Demo

**Expected behavior:**
- Entering an existing `chfId` → the field displays an error indicator (red exclamation mark)
- The save button is disabled
- The registration is blocked

**Fix applied:** The `insureeNumberValidity` query now properly handles the absence of UUID to reject already used numbers.

---

## Checklist

- [x] Unit tests added/modified
- [ ] I18n / translation handled